### PR TITLE
Create .npmignore for demo.gif

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+/demo.gif

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,9 @@
 /demo.gif
+
+# from .gitignore
+.vscode/
+node_modules/
+typings/
+jsconfig.json
+npm-debug.log
+*.tgz


### PR DESCRIPTION
First of all thank you for this package, it's really useful 👍 😃 

I've recently had some disk space issues with a project of mine and noticed that a lot of space is taken up by your package (27 MB). I figured that if you removed the _demo.gif_ using an _.npmignore_ your package would require only 100 kB of disk space (that's almost a 300x difference) – so this pull request does exactly that.

Side note: It would probably make sense to record a shorter demo, because then you could also cut down network traffic.